### PR TITLE
lib: fix missing NULL termination of SigNotation getsets list

### DIFF
--- a/lib/pygpgme-engine-info.c
+++ b/lib/pygpgme-engine-info.c
@@ -43,6 +43,7 @@ PyTypeObject PyGpgmeEngineInfo_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "gpgme.EngineInfo",
     sizeof(PyGpgmeEngineInfo),
+    .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_dealloc = (destructor)pygpgme_engine_info_dealloc,
     .tp_members = pygpgme_engine_info_members,
 };

--- a/lib/pygpgme-signature.c
+++ b/lib/pygpgme-signature.c
@@ -342,6 +342,7 @@ static PyGetSetDef pygpgme_sig_notation_getsets[] = {
     { "flags", (getter)pygpgme_sig_notation_get_flags, NULL, NULL },
     { "human_readable", (getter)pygpgme_sig_notation_get_human_readable, NULL, NULL },
     { "critical", (getter)pygpgme_sig_notation_get_critical, NULL, NULL },
+    { NULL, (getter)0, (setter)0 }
 };
 
 PyTypeObject PyGpgmeSigNotation_Type = {


### PR DESCRIPTION
The `pygpgme_sig_notation_getsets` list was missing a NULL terminator, leading to Python running off the end of the array when setting up the descriptors. While the Linux amd64 builds seemed to work despite this bug, it was causing crashes on MacOS arm64.

Fixes #9.