### PR TITLE
Protect the context with a mutex, and replace use of PyGILState_* API

### DIFF
--- a/lib/gpgme.c
+++ b/lib/gpgme.c
@@ -161,9 +161,12 @@ static PyMethodDef pygpgme_mod_functions[] = {
 };
 
 static PyModuleDef_Slot pygpgme_mod_slots[] = {
-    {Py_mod_exec, pygpgme_mod_exec},
+    { Py_mod_exec, pygpgme_mod_exec },
 #if PY_VERSION_HEX >= 0x030c0000
-    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
+    { Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED },
+#endif
+#if PY_VERSION_HEX >= 0x030d0000
+    { Py_mod_gil, Py_MOD_GIL_NOT_USED },
 #endif
     { 0, NULL },
 };

--- a/lib/pygpgme.h
+++ b/lib/pygpgme.h
@@ -22,6 +22,7 @@
 
 #define PY_SSIZE_T_CLEAN 1
 #include <Python.h>
+#include <threads.h>
 #include <gpgme.h>
 
 #define HIDDEN __attribute__((visibility("hidden")))
@@ -31,6 +32,9 @@
 typedef struct {
     PyObject_HEAD
     gpgme_ctx_t ctx;
+
+    mtx_t mutex;
+    PyThreadState *tstate;
 
     PyObject *passphrase_cb;
     PyObject *progress_cb;
@@ -191,7 +195,8 @@ HIDDEN int           pygpgme_no_constructor (PyObject *self, PyObject *args,
 HIDDEN PyObject     *pygpgme_engine_info_list_new(PyGpgmeModState *state,
                                                   gpgme_engine_info_t info);
 HIDDEN int           pygpgme_data_new       (PyGpgmeModState *state,
-                                             gpgme_data_t *dh, PyObject *fp);
+                                             gpgme_data_t *dh, PyObject *fp,
+                                             PyGpgmeContext *ctx);
 HIDDEN PyObject     *pygpgme_key_new        (PyGpgmeModState *state,
                                              gpgme_key_t key);
 HIDDEN PyObject     *pygpgme_newsiglist_new (PyGpgmeModState *state,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ disallow_untyped_calls = true
 disallow_untyped_decorators = true
 
 [tool.cibuildwheel]
+enable = ["cpython-freethreading"]
+
 manylinux-x86_64-image = "manylinux_2_28"
 musllinux-x86_64-image = "musllinux_1_2"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
+dev = [
+    'interpreters-pep-734; python_version >= "3.13"'
+]
 
 docs = [
     'Sphinx',
@@ -65,6 +68,7 @@ enable = ["cpython-freethreading"]
 manylinux-x86_64-image = "manylinux_2_28"
 musllinux-x86_64-image = "musllinux_1_2"
 
+test-extras =  ["dev"]
 test-command = "python -m unittest discover -v -t {project} {project}/tests"
 
 [tool.cibuildwheel.linux]

--- a/tests/test_multiple_interpreters.py
+++ b/tests/test_multiple_interpreters.py
@@ -1,0 +1,67 @@
+import unittest
+
+try:
+    import interpreters
+except ModuleNotFoundError:
+    try:
+        from interpreters_backport import interpreters
+    except ModuleNotFoundError:
+        interpreters = None
+
+import gpgme
+from tests.util import GpgHomeTestCase
+
+
+@unittest.skipIf(interpreters is None, "interpreters module required")
+class MultipleInterpretersTestCase(GpgHomeTestCase):
+
+    import_keys = ['key1.pub']
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.interp = interpreters.create()
+        self.addCleanup(self.interp.close)
+        self.queue = interpreters.create_queue()
+        # FIXME: Passing a queue between interpreters fails if the
+        # interpreter hasn't imported the _interpqueues module:
+        # https://github.com/ericsnowcurrently/interpreters/issues/20
+        self.interp.exec(f"import {interpreters.queues.__name__}")
+        self.interp.prepare_main(queue=self.queue)
+
+    def test_types_are_distinct(self) -> None:
+        @self.interp.call
+        def f() -> None:
+            import gpgme
+
+            queue.put((
+                ('Context', id(gpgme.Context)),
+                ('Key', id(gpgme.Key)),
+                ('PubkeyAlgo', id(gpgme.PubkeyAlgo)),
+            ))
+
+        classes = dict(self.queue.get())
+        self.assertNotEqual(classes['Context'], id(gpgme.Context))
+        self.assertNotEqual(classes['Key'], id(gpgme.Key))
+        self.assertNotEqual(classes['PubkeyAlgo'], id(gpgme.PubkeyAlgo))
+
+    def test_verify(self) -> None:
+        @self.interp.call
+        def f() -> None:
+            from io import BytesIO
+            from textwrap import dedent
+            import gpgme
+
+            signature = BytesIO(dedent('''
+                -----BEGIN PGP MESSAGE-----
+                Version: GnuPG v1.4.1 (GNU/Linux)
+
+                owGbwMvMwCTotjv0Q0dM6hLG00JJDM7nNx31SM3JyVcIzy/KSeHqsGdmBQvCVAky
+                pR9hmGfw0qo3bfpWZwun5euYAsUcVkyZMJlhfvkU6UBjD8WF9RfeND05zC/TK+H+
+                EQA=
+                =HCW0
+                -----END PGP MESSAGE-----
+                ''').encode('ASCII'))
+            plaintext = BytesIO()
+            ctx = gpgme.Context()
+            sigs = ctx.verify(signature, None, plaintext)
+            assert plaintext.getvalue() == b'Hello World\n'


### PR DESCRIPTION
All of the callbacks in pygpgme are called during one of the gpgme.Context method calls. So we know exactly which `PyThreadState` should be restored. The `PyGILState_*` API worked, but are a bigger hammer than we need.

So now we save the current `PyThreadState` in the `PyGpgmeContext` struct so callbacks can restore it directly. This would be a problem if the context is reentered, so add a mutex to prevent that.